### PR TITLE
Support ProjectGuid in issue key

### DIFF
--- a/VSSonarExtensionUi.Test/Association/StandAloneVsHelper.cs
+++ b/VSSonarExtensionUi.Test/Association/StandAloneVsHelper.cs
@@ -227,5 +227,10 @@ namespace VSSonarExtensionUi.Test.Association
         {
             throw new NotImplementedException();
         }
+
+        public VsProjectItem GetProjectByGuidInSolution(string projectGuid)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/VSSonarPlugins/IVsEnvironmentHelper.cs
+++ b/VSSonarPlugins/IVsEnvironmentHelper.cs
@@ -156,6 +156,13 @@ namespace VSSonarPlugins
         /// <returns>The <see cref="VsProjectItem"/>.</returns>
         VsProjectItem GetProjectByNameInSolution(string projectName);
 
+        /// <summary>
+        /// Gets the project by unique identifier in solution.
+        /// </summary>
+        /// <param name="projectGuid">The project unique identifier.</param>
+        /// <returns></returns>
+        VsProjectItem GetProjectByGuidInSolution(string projectGuid);
+
         /// <summary>The get file real path for solution.</summary>
         /// <param name="fileInView">The file in view.</param>
         /// <returns>The <see cref="string"/>.</returns>


### PR DESCRIPTION
Updates to SonarQube included putting the ProjectGuid from the solution
file in the issue key. This change will allow the Open in VS feature to
work with versions that do this.